### PR TITLE
Check 'mpg123' is installed.

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -1,6 +1,9 @@
 use strict;
 use warnings;
 use Module::Build;
+use Carp;
+
+requires_external_bin('mpg123');
 
 my $builder = Module::Build->new(
     name              => 'App-WithSound',
@@ -36,3 +39,48 @@ my $builder = Module::Build->new(
 );
 
 $builder->create_build_script();
+
+# Module::Install::Can
+sub can_run {
+    my $cmd = shift;
+    require ExtUtils::MakeMaker;
+    if ( $^O eq 'cygwin' ) {
+        # MM->maybe_command is fixed in 6.51_01 for Cygwin.
+        ExtUtils::MakeMaker->import(6.52);
+    }
+
+    my $_cmd = $cmd;
+    return $_cmd if ( -x $_cmd or $_cmd = MM->maybe_command($_cmd) );
+
+    for my $dir ( ( split /$Config::Config{path_sep}/x, $ENV{PATH} ), q{.} ) {
+        next if $dir eq q{};
+        my $abs = File::Spec->catfile( $dir, $cmd );
+        return $abs if ( -x $abs or $abs = MM->maybe_command($abs) );
+    }
+
+    return;
+} ## end sub can_run
+
+# Module::Install::External
+sub requires_external_bin {
+    my ($bin, $version) = @_;
+    if ($version) {
+        croak 'requires_external_bin does not support versions yet';
+    }
+
+    # Locate the bin
+    print "Locating required external dependency bin: $bin...";
+    my $found_bin = can_run($bin);
+    if ($found_bin) {
+        print " found at $found_bin.\n";
+    } else {
+        print " missing.\n";
+        print "Unresolvable missing external dependency.\n";
+        print "Please install '$bin' seperately and try again.\n";
+        print {*STDERR}
+            "NA: Unable to build distribution on this platform.\n";
+        exit 0;
+    }
+
+    return 1;
+} ## end sub requires_external_bin


### PR DESCRIPTION
Audio::Play::MPG123 is only frontend of mpg123, so it does not assure
that 'mpg123' is already installed.

If people does not install `mpg123`, they got following message by `perl Build.PL`.

```
NA: Unable to build distribution on this platform.
Locating required external dependency bin: mpg123... missing.
Unresolvable missing external dependency.
Please install 'mpg123' seperately and try again.
```
