### PR TITLE
Fix to pass test

### DIFF
--- a/lib/App/WithSound.pm
+++ b/lib/App/WithSound.pm
@@ -79,7 +79,7 @@ sub _load_sound_paths_from_env {
         WITH_SOUND_FAILURE => "failure_sound_path",
         WITH_SOUND_RUNNING => "running_sound_path",
     );
-    for my $env_name ( keys %deprecated_envs ) {
+    for my $env_name ( sort keys %deprecated_envs ) {
         if ( my $sound_file_path = $self->{env}->{$env_name} ) {
             carp
 qq{[WARNING] "$env_name" is deprecated. Please use "PERL_$env_name"\n};
@@ -93,7 +93,7 @@ qq{[WARNING] "$env_name" is deprecated. Please use "PERL_$env_name"\n};
         PERL_WITH_SOUND_FAILURE => "failure_sound_path",
         PERL_WITH_SOUND_RUNNING => "running_sound_path",
     );
-    for my $env_name ( keys %envs ) {
+    for my $env_name ( sort keys %envs ) {
         if ( my $sound_file_path = $self->{env}->{$env_name} ) {
             $self->{ $envs{$env_name} } = expand_filename($sound_file_path);
         }

--- a/t/01.load_sound_paths_from_env.t
+++ b/t/01.load_sound_paths_from_env.t
@@ -32,8 +32,8 @@ subtest 'Deprecated environment variables are specified' => sub {
     warnings_like { $app->_load_sound_paths_from_env }
         [
             qr{\[WARNING\] "WITH_SOUND_FAILURE" is deprecated. Please use "PERL_WITH_SOUND_FAILURE"},
-            qr{\[WARNING\] "WITH_SOUND_SUCCESS" is deprecated. Please use "PERL_WITH_SOUND_SUCCESS"},
             qr{\[WARNING\] "WITH_SOUND_RUNNING" is deprecated. Please use "PERL_WITH_SOUND_RUNNING"},
+            qr{\[WARNING\] "WITH_SOUND_SUCCESS" is deprecated. Please use "PERL_WITH_SOUND_SUCCESS"},
         ];
 
     is $app->{success_sound_path}, 'foo', 'success_sound_path should be "foo"';


### PR DESCRIPTION
In Perl 5.20.2, `t/01.load_sound_paths_from_env.t` fails by hash randomization.
